### PR TITLE
fix: replace setup.py/twine workflow with uv build and publish

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,44 +1,31 @@
-name: Release to PyPI
+name: Publish to PyPI
 
 on:
-
   release:
-
-    types:
-      - created
+    types: [published]
 
 jobs:
-
-  deploy:
-
+  build-and-publish:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
 
     steps:
-
-      - name: Check out code
-
-        uses: actions/checkout@v2
-
+      - uses: actions/checkout@v4
 
       - name: Set up Python
-
-        uses: actions/setup-python@v2
-
+        uses: actions/setup-python@v5
         with:
+          python-version: "3.13"
 
-          python-version: 3.x # Choose your Python version
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
 
-      - name: Install dependencies
-        run: |
-          python3 -m pip install --upgrade pip
-          pip install setuptools wheel twine
+      - name: Build package
+        run: uv build
 
-      - name: Build and publish
-        run: |
-          python3 setup.py sdist bdist_wheel
-          python3 -m twine upload dist/*.tar.gz
+      - name: Publish to PyPI
+        run: uv publish
         env:
-
-          TWINE_USERNAME: ${{ secrets.PYPI_USER }}
-          
-          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
+          UV_PUBLISH_TOKEN: ${{ secrets.PYPI_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "subprober"
-version = "3.0.2"
+version = "3.1.0"
 description = "Subprober - An essential HTTP multi-purpose Probing Tool for Penetration Testers and Security Researchers with Asynchronous httpx client support"
 readme = "README.md"
 requires-python = ">=3.13"


### PR DESCRIPTION
## Summary

- Replace broken `python3 setup.py sdist bdist_wheel` + `twine` publish step — no `setup.py` exists in the repo (pyproject.toml / setuptools backend)
- Rewrite workflow to use `uv build` + `uv publish` with `astral-sh/setup-uv@v4`
- Upgrade all action versions: `checkout@v4`, `setup-python@v5`
- Bump version to `3.1.0` in `pyproject.toml`

## Test plan

- [ ] Merge PR into main
- [ ] Create GitHub Release v3.1.0 — workflow should trigger and complete without errors
- [ ] Verify package appears on PyPI as `subprober==3.1.0`